### PR TITLE
Add TypeScript installation step on auto deployment action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Connect GitHub workflow with repository
         uses: actions/checkout@v2
+      - name: Install TypeScript
+        run: npm ci
       - run: npm run hospital
       - name: Deploy to Vercel
         uses: amondnet/vercel-action@v19.0.1+1


### PR DESCRIPTION
Merge ini menambahkan tahap instalasi _dependency_ pada saat _deployment_. Hal ini disebabkan oleh `npx ts-node <xxx>` yang tetap tidak bisa dijalankan bila tidak ada TypeScript lokal.