### PR TITLE
Remove ts-node from scraping step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Install TypeScript
         run: npm ci
       - run: npm run hospital
+        env:
+          RS_URL: https://services5.arcgis.com/VS6HdKS0VfIhv8Ct/arcgis/rest/services/RS_Rujukan_Update_May_2020/FeatureServer/0/query?f=json&where=1%3D1&returnGeometry=false&outFields=nama%2Clat%2Clon%2Calamat%2Ctelepon
       - name: Deploy to Vercel
         uses: amondnet/vercel-action@v19.0.1+1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ dist
 
 .now
 .vercel
+
+public/hospitals.json
+src/**/*.js

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint src/**/*.ts api/**/*.ts",
-    "hospital": "npx ts-node ./src/utils/scraper.ts",
+    "hospital": "tsc ./src/utils/scraper.ts --esModuleInterop && node ./src/utils/scraper.js",
     "refresh": "rm -rf node_modules/ dist/ build/ && npm i"
   },
   "keywords": [

--- a/src/utils/scraper.ts
+++ b/src/utils/scraper.ts
@@ -35,4 +35,5 @@ getHospitalsData()
   })
   .catch((err: Error) => {
     console.error(err.message);
+    throw err; // re-throw
   });


### PR DESCRIPTION
Merge ini menghilangkan _dependency_ `ts-node` pada saat proses _scrapping_ dilakukan. Hal ini dilakukan untuk menyederhanakan _workflow_ pada saat _build step_.