### PR TITLE
Remove 117 from contact list

### DIFF
--- a/public/replies.json
+++ b/public/replies.json
@@ -22,6 +22,6 @@
     "how": "Penularan COVID-19 terjadi melalui droplet (tetesan kecil) yang keluar dari mulut atau hidung penderita ketika batuk, bersin, atau berbicara.\n\nOrang lain dapat terinfeksi apabila orang tersebut mengalami kontak dengan droplet tersebut kemudian menyentuh daerah mata, bibir, dan hidung.",
     "symptoms": "Orang yang terinfeksi virus ini akan mengalami gejala-gejala seperti:\n1. Demam,\n2. Batuk Kering,\n3. Kelelahan,\n4. Sakit Kepala, dan masih banyak lagi.\n\nApabila anda mengalami gejala-gejala tersebut dan anda pernah mengalami kontak dengan orang yang terinfeksi dalam 2 minggu terakhir, segera konsultasikan diri anda pada fasilitas kesehatan terdekat.",
     "todo": "Anda dapat melakukan hal-hal berikut:\n1. Rajinlah mencuci tangan dengan sabun atau pembersih tangan berbasis alkohol minimal 60%.\n2. Jaga jarak dengan orang yang tampak sakit sejauh kurang lebih 1 meter.\n3. Hindari menyentuh mata, mulut, dan hidung secara langsung\n4. Ketika batuk, tutup mulut menggunakan lipatan siku atau tissue.\n5. Kurangi aktivitas diluar rumah yang tidak mendesak.",
-    "contact": "Anda dapat menghubungi pihak terkait melalui media berikut:\n\nCall Center ☎️: 119\nNomor Pelayanan Darurat ☎️: 117\nWebsite 🌐: covid19.go.id"
+    "contact": "Anda dapat menghubungi pihak terkait melalui media berikut:\n\nCall Center ☎️: 119\nWebsite 🌐: covid19.go.id"
   }
 }


### PR DESCRIPTION
Merge ini menghapus informasi nomor 117 dari daftar kontak gugus tugas penanganan COVID-19 BNPB, karena nomor tersebut bukan nomor nasional.